### PR TITLE
Release v3.0.1 — multi-file upload (totalFiles)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worky-file-service",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "File upload and processing service with image/video optimization",
   "author": "",
   "private": true,

--- a/src/upload/upload.controller.ts
+++ b/src/upload/upload.controller.ts
@@ -64,6 +64,7 @@ export class UploadController {
       idReference?: string;
       urlMedia?: string;
       type?: string;
+      totalFiles?: string;
     },
   ) {
     // authHeader has already been validated by JwtAuthGuard; we only need the raw value
@@ -138,7 +139,13 @@ export class UploadController {
       };
     }
 
-    const totalFiles = files.length;
+    // When the client splits a multi-file upload into one request per file (to stay under the
+    // edge body-size limit), it sends the real total so the completion notification still
+    // batches across requests. Fall back to this request's file count otherwise.
+    const totalFiles =
+      body.totalFiles && Number(body.totalFiles) > 0
+        ? Number(body.totalFiles)
+        : files.length;
     for (const file of files) {
       await this.fileProcessingQueue.add('fileProcessing', {
         file,


### PR DESCRIPTION
## v3.0.1 (patch)

Pequeño fix: el endpoint `/upload` ahora respeta `totalFiles` del body para agrupar correctamente la notificación de "media lista" cuando el cliente sube los archivos en requests separados (uno por archivo, para no exceder el límite de tamaño del borde).

🤖 Generated with [Claude Code](https://claude.com/claude-code)