### PR TITLE
Release v3.1.1 — video thumbnail aspect fix

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: file-service
-        image: socialworky/worky-file-service-dev:b4b025c55207b1374825f5777c338dc0d676142b
+        image: socialworky/worky-file-service-dev:16ac23f7fc946e7637bcef0e4f346f1776441d69
         ports:
         # Port comes from APP_PORT environment variable (must be in file-service-env-vars secret)
         # IMPORTANT: This value MUST match APP_PORT in the secret

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worky-file-service",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "File upload and processing service with image/video optimization",
   "author": "",
   "private": true,

--- a/src/upload/upload.service.ts
+++ b/src/upload/upload.service.ts
@@ -411,7 +411,9 @@ export class UploadService {
           count: 1,
           folder: outputDir,
           filename: thumbnailFilename,
-          size: '640x360',
+          // Width-capped, aspect-preserving ('?' computes the height). A fixed '640x360'
+          // stretched portrait frames into a distorted landscape poster.
+          size: '640x?',
           timemarks: [String(bestTs)],
         })
         .on('end', () => {


### PR DESCRIPTION
Bump 3.1.1. El thumbnail/póster de video preserva aspect ratio (640x?) en vez de forzar 640x360, que deformaba videos verticales.